### PR TITLE
[Feat] [Multi System] 캐릭터 현재 체력 동기화 및 캐릭터 랜덤 픽

### DIFF
--- a/PrototypeTest/Assets/00_Scripts/CharacterImplment/Character.cs
+++ b/PrototypeTest/Assets/00_Scripts/CharacterImplment/Character.cs
@@ -207,10 +207,9 @@ namespace CharacterImplement
 
 		public void TakeHit(int damage)
 		{
-            if (true == photonView.IsMine)
+            //if (true == photonView.IsMine)
             {
-                CurHP -= damage;
-                HealthModel.SetCurHealth(CurHP);
+				CurHP = System.Math.Max(CurHP - damage, 0);
                 photonView.RPC("UpdateCurHPRPC", RpcTarget.All, CurHP);
             }
 		}
@@ -218,6 +217,10 @@ namespace CharacterImplement
 		[PunRPC]
 		public void UpdateCurHPRPC(int newHP)
 		{
+			if (photonView.IsMine)
+			{
+				HealthModel.SetCurHealth(newHP);
+			}
 			CurHP = newHP;
 		}
 

--- a/PrototypeTest/Assets/00_Scripts/CharacterImplment/Character.cs
+++ b/PrototypeTest/Assets/00_Scripts/CharacterImplment/Character.cs
@@ -1,6 +1,7 @@
 using Cysharp.Threading.Tasks;
 using Photon.Pun;
 using System.Threading;
+using UniRx;
 using UnityEngine;
 using UnityEngine.AI;
 
@@ -69,7 +70,13 @@ namespace CharacterImplement
 			_source2.Cancel();
 
 			CurHP = MaxHP;
-		}
+
+			if (true == photonView.IsMine)
+			{
+				HealthModel.SetCurHealth(CurHP);
+				HealthModel.SetMaxHealth(MaxHP);
+			}
+        }
 
 		void Start()
         {
@@ -200,13 +207,18 @@ namespace CharacterImplement
 
 		public void TakeHit(int damage)
 		{
-			photonView.RPC("TakeHitRPC", RpcTarget.All, damage);
+            if (true == photonView.IsMine)
+            {
+                CurHP -= damage;
+                HealthModel.SetCurHealth(CurHP);
+                photonView.RPC("UpdateCurHPRPC", RpcTarget.All, CurHP);
+            }
 		}
 
 		[PunRPC]
-		public void TakeHitRPC(int damage)
+		public void UpdateCurHPRPC(int newHP)
 		{
-			CurHP -= damage;
+			CurHP = newHP;
 		}
 
 		public void OnAnimationEnd()

--- a/PrototypeTest/Assets/00_Scripts/LobbyScripts/Network/PlayerNetwork.cs
+++ b/PrototypeTest/Assets/00_Scripts/LobbyScripts/Network/PlayerNetwork.cs
@@ -97,8 +97,13 @@ public class PlayerNetwork : MonoBehaviour
     private void RPC_CreatePlayer()
     {
         float randomValue = Random.Range(0, 5f);
-        //GameObject obj = PhotonNetwork.Instantiate(Path.Combine("Prefab", "Player_Ricky"), new Vector3(0f, 1f, -9f), Quaternion.identity, 0);
-        GameObject obj = PhotonNetwork.Instantiate(Path.Combine("Prefab", "Player_Rio"), new Vector3(0f, 1f, -9f), Quaternion.identity, 0);
+        int randomInteger = Random.Range(0, 10);
+        string playerPrefabName = "";
+        if (5 > randomInteger)
+            playerPrefabName = Path.Combine("Prefab", "Player_Rio");
+        else
+            playerPrefabName = Path.Combine("Prefab", "Player_Nicky");
+        GameObject obj = PhotonNetwork.Instantiate(playerPrefabName, new Vector3(0f, 1f, -9f), Quaternion.identity, 0);
         CurrentPlayer = obj.GetComponent<PlayerMovement>();
     }
 }

--- a/PrototypeTest/Assets/00_Scripts/LobbyScripts/Network/PlayerNetwork.cs
+++ b/PrototypeTest/Assets/00_Scripts/LobbyScripts/Network/PlayerNetwork.cs
@@ -105,5 +105,7 @@ public class PlayerNetwork : MonoBehaviour
             playerPrefabName = Path.Combine("Prefab", "Player_Nicky");
         GameObject obj = PhotonNetwork.Instantiate(playerPrefabName, new Vector3(0f, 1f, -9f), Quaternion.identity, 0);
         CurrentPlayer = obj.GetComponent<PlayerMovement>();
+
+        SceneManager.LoadScene("HUD_Test", LoadSceneMode.Additive);
     }
 }


### PR DESCRIPTION
# 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
- 멀티 환경에서 현재 체력 동기화
- 캐릭터 랜덤 픽

# 변경된 내용
- RPC함수를 사용해 HP가 깎일 때 모든 사용자에게 전달
> 나의 체력이 깎일 때는 다른 상대방의 클라이언트라 깎인 체력을 전달해주기 위해
- 현재 체력 변경 시 photonView.IsMine을 체크해 true인 경우 UI Model에 데이터 전달
- Random.Range를 사용해 50%, 50% 확률로 리오 또는 니키가 픽되게 구현

# 스크린샷 / 동영상


https://github.com/Team-FM/PrototypeTest/assets/120010342/99db0c8c-7ef1-42e9-a325-69d7f7a6c221




# 관련 이슈
- #15
